### PR TITLE
Patch: Update chromium flag

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -135,7 +135,7 @@ let launchChromium = async function(url) {
         let gpuFlags = [
           '--enable-zero-copy',
           '--num-raster-threads=4',
-          '--ignore-gpu-blacklist',
+          '--ignore-gpu-blocklist',
           '--enable-gpu-rasterization',
         ];
 


### PR DESCRIPTION
The flag got renamed to --ignore-gpu-blocklist otherwise Hardware acceleration does not work