### PR TITLE
Update to Debian 11 and node 16

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
-ARG NODEJS_VERSION="12.22.12"
+ARG NODEJS_VERSION="16.19.1"
 
-FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-node:${NODEJS_VERSION}-buster-run
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-node:${NODEJS_VERSION}-bullseye-run
 
 # install required packages
 RUN install_packages \


### PR DESCRIPTION
The block is currently based on Debain 10, however its mesa version is too old for RPi kernel 5.15.9 and up which results in X server crashing on startup.

This patch updates the base to Debian 11 and bumps to node 16, which works on all architectures.