### PR TITLE
Removes wget package from dockerfile

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -10,7 +10,6 @@ RUN install_packages \
     lsb-release \
     mesa-vdpau-drivers \
     scrot \
-    wget \
     x11-xserver-utils \
     xserver-xorg-input-evdev \
     xserver-xorg-legacy \


### PR DESCRIPTION
Change-type: patch
Removes the 'wget' package from the Dockerfile template, resulting in a Docker image size reduction to approximately 754.92MB (compared to ~755.86MB). Every bit counts, right? #42

P.S.:

Also noticed this [branch](https://github.com/balena-labs-projects/browser/commit/f4451e1288609777a121d49fe08a5db9a7096004) about updating the base image to Debian 12 for Balena Browser. Woulid be awesome to have latest stable software with the same functionality however, it's worth mentioning that going with Debian 12 (Bookworm) would significantly increase the Docker image size to 1 GB+. This got me thinking about alternative approaches. To ensure both the latest mesa version and a relatively small Docker image, I decided to undertake a rewrite of the project [here](https://github.com/Iznogohul/browser)

Rewrite inclues
* NestJs
* Swagger Docs (sort of)
* latest LTS Node.js version that balena supports
* Removed bent package in favor of native fetch
* Alpine as the base docker image + multi staged build
As a result, the Docker image size was around ~750MB. 
However, to ensure optimal performance and compatibility on real hardware, further testing is required. Currently, I only have an RPi3 B+ available for testing.
