### PR TITLE
Add EXTRA_FLAGS for extended flag support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,7 +81,8 @@ The following environment variables allow configuration of the `browser` block:
 |`LOCAL_HTTP_DELAY`|Number (seconds)|0|Number of seconds to wait for a local HTTP service to start before trying to detect it|
 |`KIOSK`|`0`, `1`|`0`|Run in kiosk mode with no menus or status bars. <br/> `0` = off, `1` = on|
 |`SHOW_CURSOR`|`0`, `1`|`0`|Enables/disables the cursor when in kiosk mode<br/> `0` = off, `1` = on|
-|`FLAGS`|[many!](https://peter.sh/experiments/chromium-command-line-switches/)|N/A|Overrides the flags chromium is started with. Enter a space (\' \') separated list of flags (e.g. `--noerrdialogs --disable-session-crashed-bubble`) <br/> **Use with caution!**|
+|`FLAGS`|[many!](https://peter.sh/experiments/chromium-command-line-switches/)|N/A|**Replaces** the flags chromium is started with. Enter a space (\' \') separated list of flags (e.g. `--noerrdialogs --disable-session-crashed-bubble`) <br/> **Use with caution!**|
+|`EXTRA_FLAGS`|[many!](https://peter.sh/experiments/chromium-command-line-switches/)|N/A|Adds **additional** flags chromium is started with. Enter a space (\' \') separated list of flags (e.g. `--audio-buffer-size=2048 --audio-output-channels=8`)|
 |`PERSISTENT`|`0`, `1`|`0`|Enables/disables user profile data being stored on the device. **Note: you'll need to create a settings volume. See example above** <br/> `0` = off, `1` = on|
 |`ROTATE_DISPLAY`|`normal`, `left`, `right`, `inverted`|`normal`|Rotates the display|
 |`TOUCHSCREEN`|`string`|N\A|Name of Touch Input to rotate|

--- a/src/server.js
+++ b/src/server.js
@@ -20,6 +20,7 @@ const WINDOW_POSITION = process.env.WINDOW_POSITION || "0,0";
 const PERSISTENT_DATA = process.env.PERSISTENT || '0';
 const REMOTE_DEBUG_PORT = process.env.REMOTE_DEBUG_PORT || 35173;
 const FLAGS = process.env.FLAGS || null;
+const EXTRA_FLAGS = process.env.EXTRA_FLAGS || null;
 const HTTPS_REGEX = /^https?:\/\//i //regex for HTTP/S prefix
 
 // Environment variables which can be overriden from the API
@@ -141,6 +142,10 @@ let launchChromium = async function(url) {
 
         flags = flags.concat(gpuFlags);
       }
+    }
+
+    if (EXTRA_FLAGS) {
+      flags = flags.concat(EXTRA_FLAGS.split(' '));
     }
 
     let startingUrl = url;


### PR DESCRIPTION
This adds a new environment variable EXTRA_FLAGS so we can extend the existing flags passed to Chromium instead of clobbering them all with FLAGS and trying to reproduce the whole list ourselves.

For example, for our IoT project we need `--audio-buffer-size=2048` and `--audio-output-channels=8`, so we can do this:

```yaml
services:
  browser:
    image: bh.cr/balenalabs/browser-<arch>
    environment:
      EXTRA_FLAGS: --audio-buffer-size=2048 --audio-output-channels=8
```

instead of having this monstrosity (which requires us to keep track of window sizes):

```yaml
services:
  browser:
    image: bh.cr/balenalabs/browser-<arch>
    environment:
      FLAGS: >-
        --disable-features=TranslateUI
        --disable-component-extensions-with-background-pages
        --disable-background-networking
        --disable-sync
        --metrics-recording-only
        --disable-default-apps
        --no-default-browser-check
        --no-first-run
        --disable-backgrounding-occluded-windows
        --disable-renderer-backgrounding
        --disable-background-timer-throttling
        --force-fieldtrials=*BackgroundTracing/default/
        --window-size=1920,1080
        --window-position=0,0
        --autoplay-policy=no-user-gesture-required
        --noerrdialogs
        --disable-session-crashed-bubble
        --check-for-update-interval=31536000
        --disable-dev-shm-usage
        --enable-zero-copy
        --num-raster-threads=4
        --ignore-gpu-blocklist
        --enable-gpu-rasterization
        --audio-buffer-size=2048
        --audio-output-channels=8
```