### PR TITLE
/usr/bin/entry.sh is executed twice

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -3,9 +3,6 @@
 # this allows chromium sandbox to run, see https://github.com/balena-os/meta-balena/issues/2319
 sysctl -w user.max_user_namespaces=10000
 
-# Run balena base image entrypoint script
-/usr/bin/entry.sh echo "Running balena base image entrypoint..."
-
 export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 
 sed -i -e 's/console/anybody/g' /etc/X11/Xwrapper.config


### PR DESCRIPTION
we removed line /usr/bin/entry.sh echo "Running balena base image entrypoint..." from /usr/src/app/start.sh as this /usr/bin/entry.sh is already being run as an entrypoint by Dockerfile and thus it was being run twice and udev deamon as well twice, which is wrong...

Running two udev daemons caused issues with reconnecting USB devices.